### PR TITLE
bump go 1.24, improve MaybeWithDiskKeyPair validation, add ForKind.String

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ cfg, err := tlscfg.New(
                 "cert.pem",
                 "key.pem",
         ),
+        tlscfg.WithSystemCertPool(), // use system certs in addition to custom CA
 )
 if err != nil {
         // handle

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/twmb/tlscfg
 
-go 1.17
+go 1.24

--- a/tlscfg.go
+++ b/tlscfg.go
@@ -20,6 +20,7 @@
 //	                "cert.pem",
 //	                "key.pem",
 //	        ),
+//	        tlscfg.WithSystemCertPool(), // use system certs in addition to custom CA
 //	)
 //	if err != nil {
 //	        // handle
@@ -51,12 +52,24 @@ type ForKind uint8
 
 const (
 	// ForServer specifies that an option should work on server portions
-	// of a *tls.Config (adding a CA).
+	// of a *tls.Config (adding a CA), setting RequireAndVerifyClientCert.
 	ForServer ForKind = iota
 	// ForClient specifies that an option should work on client portions
 	// of a *tls.Config (adding a CA).
 	ForClient
 )
+
+// String returns the name of the ForKind.
+func (f ForKind) String() string {
+	switch f {
+	case ForServer:
+		return "ForServer"
+	case ForClient:
+		return "ForClient"
+	default:
+		return fmt.Sprintf("ForKind(%d)", f)
+	}
+}
 
 // CipherSuites returns this package's recommended ciphers that tls
 // configurations should use.
@@ -97,6 +110,9 @@ func MaybeWithDiskKeyPair(certPath, keyPath string) Opt {
 	return &opt{func(fs FS, cfg *tls.Config) error {
 		if certPath == "" && keyPath == "" {
 			return nil
+		}
+		if certPath == "" || keyPath == "" {
+			return errors.New("both cert and key paths must be specified, or both must be empty")
 		}
 		return WithDiskKeyPair(certPath, keyPath).apply(fs, cfg)
 	}}

--- a/tlscfg_test.go
+++ b/tlscfg_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -24,8 +25,8 @@ var (
 		0x20, 0x43, 0x41, 0x31, 0x12, 0x30, 0x10, 0x06, 0x03, 0x55,
 		0x04, 0x05, 0x13, 0x09,
 	}
-	subject1 = append(subjectBase, "196629234"...)
-	subject2 = append(subjectBase, "885211544"...)
+	subject1 = slices.Concat(subjectBase, []byte("196629234"))
+	subject2 = slices.Concat(subjectBase, []byte("885211544"))
 )
 
 func TestMaybe(t *testing.T) {
@@ -73,6 +74,15 @@ func TestMaybe(t *testing.T) {
 		}
 		if len(cfg.Certificates) != 1 {
 			t.Errorf("unexpectedly %d certificates when expecting 1 when non-empty keypair", len(cfg.Certificates))
+		}
+	}
+
+	{
+		_, err := New(
+			MaybeWithDiskKeyPair("testdata/client-cert.pem", ""),
+		)
+		if err == nil {
+			t.Error("expected error for mismatched keypair paths")
 		}
 	}
 }
@@ -185,5 +195,30 @@ func TestMultiRootCA(t *testing.T) {
 				t.Errorf("got subjects != exp subjects")
 			}
 		})
+	}
+}
+
+func TestWithServerName(t *testing.T) {
+	cfg, err := New(WithServerName("example.com"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ServerName != "example.com" {
+		t.Errorf("got server name %q, expected %q", cfg.ServerName, "example.com")
+	}
+}
+
+func TestWithAdditionalCipherSuites(t *testing.T) {
+	extra := tls.TLS_RSA_WITH_AES_256_GCM_SHA384
+	cfg, err := New(WithAdditionalCipherSuites(extra))
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := CipherSuites()
+	if len(cfg.CipherSuites) != len(base)+1 {
+		t.Fatalf("got %d cipher suites, expected %d", len(cfg.CipherSuites), len(base)+1)
+	}
+	if cfg.CipherSuites[len(cfg.CipherSuites)-1] != extra {
+		t.Error("additional cipher suite not appended")
 	}
 }


### PR DESCRIPTION
- bump minimum Go version from 1.17 to 1.24
- MaybeWithDiskKeyPair now returns a clear error when only one of cert/key is provided rather than falling through to WithDiskKeyPair
- add String method to ForKind
- add WithSystemCertPool to doc examples
- use slices.Concat in tests to avoid append capacity footgun
- add tests for WithServerName and WithAdditionalCipherSuites